### PR TITLE
ci: make release run with custom PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Run Release
         run: yarn release-it --ci
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
the default `GITHUB_TOKEN` secret doesn't trigger subsequent actions, thus we'll use `GH_TOKEN`, a custom PAT that'll allow us to publish to dockerhub after a successful release